### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Webmin is a web-based interface for system administration for Unix. Using any mo
 * This app has **root** access which can change core things in the system, thus **breaking the YunoHost**. Use it carefully and read the [documents](https://doxfer.webmin.com/Webmin/Main_Page) two times before changing values.
 * Only **root** (system user) can connect 
 * Webmin will **update itself** when system updates are run. So no need to **run upgrade script** once installed.
-* Only **user** given permission at time of the installation can **access** the Webmin 
+* It is the **root** user that must be used to log in to webmin after installation.
 
 ## Documentation and resources
 


### PR DESCRIPTION
It is the **root** user that must be used to log in to Webmin, otherwise we get the following error when trying to log in with the LDAP user select during installation : 

```
Warning!
Login failed. Please try again.
```

Correction made on the Readme.md
